### PR TITLE
Fix publish sensitive data bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,7 @@ jobs:
           check-latest: true
       - name: Set up Mage
         run: go run mage.go ConfigureAgent
-      - name: Test
+      - name: Build
         run: mage -v Build
+      - name: Test
+        run: mage -v Test

--- a/mage/examples/examples.go
+++ b/mage/examples/examples.go
@@ -2,10 +2,11 @@ package examples
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 )
 
 // GetBundleRef builds the reference to the specified example bundle, given a registry override.
@@ -21,9 +22,21 @@ func GetBundleRef(bundleDir string, registryOverride string) (string, error) {
 		return "", fmt.Errorf("error parsing porter manifest at %s: %w", manifestPath, err)
 	}
 
-	name := manifest["name"].(string)
-	version := manifest["version"].(string)
-	registry := manifest["registry"].(string)
+	name, ok := manifest["name"].(string)
+	if !ok {
+		return "", fmt.Errorf("name was not defined in %s", manifestPath)
+	}
+
+	version, ok := manifest["version"].(string)
+	if !ok {
+		return "", fmt.Errorf("version was not defined in %s", manifestPath)
+	}
+
+	registry, ok := manifest["registry"].(string)
+	if !ok {
+		return "", fmt.Errorf("registry was not defined in %s", manifestPath)
+	}
+
 	if registryOverride != "" {
 		registry = registryOverride
 	}

--- a/mage/examples/examples_test.go
+++ b/mage/examples/examples_test.go
@@ -1,13 +1,14 @@
 package examples
 
 import (
+	"io/ioutil"
+	"os"
+	"testing"
+
 	"github.com/carolynvs/magex/mgx"
 	"github.com/carolynvs/magex/shx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
-	"testing"
 )
 
 func TestListExampleBundles(t *testing.T) {
@@ -25,7 +26,24 @@ func TestListExampleBundles(t *testing.T) {
 }
 
 func TestGetBundleRef(t *testing.T) {
-	ref, err := GetBundleRef("../../hello", "localhost:5000")
-	require.NoError(t, err)
-	assert.Equal(t, "localhost:5000/examples/hello:v0.2.0", ref)
+	t.Run("valid manifest", func(t *testing.T) {
+		ref, err := GetBundleRef("../../hello", "localhost:5000")
+		require.NoError(t, err)
+		assert.Equal(t, "localhost:5000/examples/porter-hello:v0.2.0", ref)
+	})
+
+	t.Run("missing registry", func(t *testing.T) {
+		_, err := GetBundleRef("testdata/missing-registry", "localhost:5000")
+		assert.EqualError(t, err, "registry was not defined in testdata/missing-registry/porter.yaml")
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		_, err := GetBundleRef("testdata/missing-name", "localhost:5000")
+		assert.EqualError(t, err, "name was not defined in testdata/missing-name/porter.yaml")
+	})
+
+	t.Run("missing version", func(t *testing.T) {
+		_, err := GetBundleRef("testdata/missing-version", "localhost:5000")
+		assert.EqualError(t, err, "version was not defined in testdata/missing-version/porter.yaml")
+	})
 }

--- a/mage/examples/testdata/missing-name/porter.yaml
+++ b/mage/examples/testdata/missing-name/porter.yaml
@@ -1,0 +1,2 @@
+version: 0.1.0
+registry: myregistry

--- a/mage/examples/testdata/missing-registry/porter.yaml
+++ b/mage/examples/testdata/missing-registry/porter.yaml
@@ -1,0 +1,3 @@
+name: missing-registry
+version: 0.1.0
+reference: localhost:5000/missing-registry

--- a/mage/examples/testdata/missing-version/porter.yaml
+++ b/mage/examples/testdata/missing-version/porter.yaml
@@ -1,0 +1,2 @@
+name: missing-registry
+registry: myregistry

--- a/magefile.go
+++ b/magefile.go
@@ -7,14 +7,15 @@ package main
 
 import (
 	"fmt"
-	"get.porter.sh/example-bundles/mage/examples"
-	"get.porter.sh/example-bundles/mage/setup"
-	"get.porter.sh/magefiles/porter"
-	"github.com/carolynvs/magex/mgx"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"get.porter.sh/example-bundles/mage/examples"
+	"get.porter.sh/example-bundles/mage/setup"
+	"get.porter.sh/magefiles/porter"
+	"github.com/carolynvs/magex/mgx"
 
 	// mage:import
 	_ "get.porter.sh/magefiles/ci"
@@ -25,6 +26,10 @@ import (
 
 func Build() {
 	mg.Deps(BuildExamples)
+}
+
+func Test() error {
+	return shx.RunV("go", "test", "./...")
 }
 
 // BuildExamples builds every example bundle

--- a/sensitive-data/porter.yaml
+++ b/sensitive-data/porter.yaml
@@ -1,8 +1,8 @@
 schemaVersion: 1.0.0-alpha.1
-name: sensitive-data
+name: examples/sensitive-data
 version: 0.1.0
-description: "An example bundle that generates sensitive data "
-reference: ghcr.io/getporter
+description: "An example bundle that generates sensitive data"
+registry: ghcr.io/getporter
 
 parameters:
   - name: name


### PR DESCRIPTION
[Detect malformed manifest during publish](https://github.com/getporter/examples/commit/b2d8302fda721c24e0c41f0021e713335d9beb28)

In one spot of publish we calculate the location where the bundle will be published, and then do a check for if it's already published so that we can skip bundles that don't need to be published.

The sensitive-data bundle wasn't setting registry, and instead had reference set. This caused a type cast to fail during the above calculation.

I've updated GetBundleRef to detect and return an error when the example bundle isn't set up the way we expect (with a name, version and registry defined).


[Fix definition of sensitive-data bundle](https://github.com/getporter/examples/commit/32965f89a64c25eb55a587d85a1ce9daf462cb6f)

I've fixed the definition of the sensitive-data bundle to be consistent with what our publish logic expects. The bundle now has a registry set, instead of reference. The bundle name is prefixed with examples/ so that its eventual publish location will be:

`ghcr.io/getporter/examples/sensitive-data`