### PR TITLE
(feat): make example/otel-jeager work

### DIFF
--- a/otel-jaeger/docker-compose.yaml
+++ b/otel-jaeger/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
   # If we were cool, we would use the agent, etc directly and configure
   # persistent storage. But this bundle is really designed for local dev.
   jaeger-all-in-one:
-    image: jaegertracing/all-in-one:latest
+    image: "jaegertracing/all-in-one:1.49"
     ports:
       - "${JAEGER_UI_PORT}:16686"
       - "14250"
@@ -13,7 +13,7 @@ services:
 
   # Collector
   otel-collector:
-    image: "otel/opentelemetry-collector-contrib-dev:latest"
+    image: "otel/opentelemetry-collector-contrib:0.84.0"
     volumes:
       - otel-jaeger-config:/etc/otel
     ports:

--- a/otel-jaeger/porter.yaml
+++ b/otel-jaeger/porter.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 1.0.0-alpha.1
 name: examples/otel-jaeger
-version: 0.1.0
+version: 0.1.1
 description: "Runs Jaeger with an OpenTelemetry collector"
 registry: ghcr.io/getporter
 
@@ -29,7 +29,7 @@ install:
         - "hello"
   - exec:
       description: "Create OpenTelemetry configuration"
-      command: helpers.sh
+      command: ./helpers.sh
       arguments:
         - set-config
   - docker-compose:


### PR DESCRIPTION
- We were pulling latest which made everything very mad. Pushed up back to the last week. We need to update `otel` and friends in Porter - as well as update this example to not be passing in `jeager` as an exporter.
Here's how to recreate:
Use the bundle *before* this fix. `porter install otel-jaeger -r=ghcr.io/getporter/examples/otel-jaeger:v0.1.0 --allow-docker-host-access` 

Then check your containers, the collector container should be upset - if you get its logs you'll see:
```
* error decoding 'exporters': unknown type: "jaeger" for id: "jaeger" (valid values: [logging instana otlp azuredataexplorer azuremonitor f5cloud influxdb logicmonitor awskinesis coralogix elasticsearch loadbalancing loki sumologic awscloudwatchlogs awsxray carbon dataset otlphttp alibabacloud_logservice awss3 clickhouse dynatrace googlecloudpubsub kafka parquet zipkin cassandra datadog googlemanagedprometheus logzio prometheus prometheusremotewrite pulsar sapm splunk_hec awsemf file googlecloud opencensus sentry tanzuobservability tencentcloud_logservice mezmo signalfx skywalking])
```

I think if we update the config we are passing in to not pass in `jeager` that would solve this, but then leaves the question of what are we supposed to do to configure the two containers (the collector and jeager all in one) to do to talk?

- helpers.sh didn't have `./` before it in the install which led to this error (users will still have this when pulling pre v0.1.1):
```
mixin execution failed: package command failed /cnab/app/cnab/app/mixins/exec/runtimes/exec-runtime install
                                /cnab/app helpers.sh set-config
                                couldn't run command /cnab/app helpers.sh set-config: exec: "helpers.sh": executable file not found in $PATH
                                Error: couldn't run command /cnab/app helpers.sh set-config: exec: "helpers.sh": executable file not found in $PATH
```
