### PR TITLE
Improve the sensitive sample

### DIFF
--- a/sensitive-data/porter.yaml
+++ b/sensitive-data/porter.yaml
@@ -8,16 +8,17 @@ parameters:
   - name: name
     type: string
     default: example-bundle
-    path: /cnab/app/foo/name.txt
-    source:
-      output: name
   - name: password
     type: string
+    path: /cnab/app/foo/password.txt
+    source:
+      output: admin-password
     sensitive: true
 
 outputs:
-  - name: name
-    path: /cnab/app/foo/name.txt
+  - name: admin-password
+    type: string
+    path: /cnab/app/foo/password.txt
     sensitive: true
 
 mixins:


### PR DESCRIPTION
Update porter.yaml to modify parameters and outputs for sensitive data handling

- Changed the output name from 'name' to 'admin-password'
- Updated the path for the password parameter and output
- Marked the password output as sensitive

closes #14 